### PR TITLE
fix: error with microfrontend frameworks.

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ const openUriWithTimeoutHack = (uri, failCb, successCb) => {
 
   const handler = registerEvent(target, "blur", onBlur);
 
-  window.location = uri;
+  window.location.href = uri;
 };
 
 const openUriUsingFirefox = (uri, failCb, successCb) => {


### PR DESCRIPTION
Today here are some microfrontend frameworks which create js sandbox using Proxy object, like qiankun. 

https://qiankun.umijs.org/

This kind of sandbox may have problem with set `window.location` direactly.

And I think set location.href won't makes any bug.